### PR TITLE
[feat] 측정소 알림 전송하는 로직 구현 및 트러블슈팅 

### DIFF
--- a/src/main/java/com/example/realq/domain/client/region/RegionSendClient.java
+++ b/src/main/java/com/example/realq/domain/client/region/RegionSendClient.java
@@ -24,12 +24,12 @@ public class RegionSendClient {
     private final RegionGetClient regionGetClient;
     private final NotificationRegionRepository notificationRegionRepository;
 
-    @Scheduled(cron = "0 0 5,12,17 * * *")
+    @Scheduled(cron = "0 0 7,12,17 * * *")
     public void sendAverageRegion() {
         log.info("메서드 실행: sendAverageRegion");
 
         List<AverageRegion> averageRegionList = regionGetClient.getAverageRegion();
-        List<NotificationRegion> notificationRegionList = notificationRegionRepository.findAll();
+        List<NotificationRegion> notificationRegionList = notificationRegionRepository.findAllByEnabledTrue();
 
         Map<String, String> userSlackIdToMessage = fetchAlertTargets(notificationRegionList, averageRegionList);
 
@@ -43,7 +43,6 @@ public class RegionSendClient {
         Map<String, String> alertMap = new HashMap<>();
 
         for (NotificationRegion notification : notificationRegionList) {
-            if (!notification.isEnabled()) continue;
 
             averageRegionList.stream()
                     .filter(averageRegion -> averageRegion.getRegionName().equals(notification.getRegion().getName()))

--- a/src/main/java/com/example/realq/domain/client/station/StationSendClient.java
+++ b/src/main/java/com/example/realq/domain/client/station/StationSendClient.java
@@ -1,0 +1,86 @@
+package com.example.realq.domain.client.station;
+
+import com.example.realq.domain.average.station.AverageStation;
+import com.example.realq.domain.notification.station.entity.NotificationStation;
+import com.example.realq.domain.notification.station.repository.NotificationStationRepository;
+import com.example.realq.domain.slack.SlackService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+@Transactional
+public class StationSendClient {
+
+    private final SlackService slackService;
+    private final StationGetClient stationGetClient;
+    private final NotificationStationRepository notificationStationRepository;
+
+    @Scheduled(cron = "0 0 7,12,17 * * *")
+    public void sendAverageStation() {
+        log.info("메서드 실행: sendAverageStation");
+
+        List<AverageStation> averageStationList = stationGetClient.getAverageStation();
+
+        List<NotificationStation> notificationStationList = notificationStationRepository.findAllByEnabledTrue();
+
+        Map<String, String> userSlackIdToMessage = fetchAlertTargets(notificationStationList, averageStationList);
+
+        userSlackIdToMessage.forEach(slackService::sendMessageToUser);
+
+    }
+
+    private Map<String, String> fetchAlertTargets(
+            List<NotificationStation> notificationStationList,
+            List<AverageStation> averageStationList
+    ) {
+        Map<String, String> alertMap = new HashMap<>();
+
+        for (NotificationStation notification : notificationStationList) {
+
+            String stationName = notification.getStation().getName();
+
+            averageStationList.stream()
+                    .filter(averageStation -> averageStation.getStationName().equals(stationName))
+                    .findFirst()
+                    .ifPresent(averageStation -> {
+                        int pm10 = Integer.parseInt(averageStation.getPm10Value());
+                        int pm25 = Integer.parseInt(averageStation.getPm25Value());
+
+                        if (pm10 > notification.getPm10Threshold() || pm25 > notification.getPm25Threshold()) {
+                            String message = buildAlertMessage(stationName, pm10, pm25, notification);
+                            alertMap.put(notification.getUser().getSlackId(), message);
+                        }
+                    });
+        }
+
+        return alertMap;
+    }
+
+    private String buildAlertMessage(String stationName, int pm10, int pm25, NotificationStation notificationStation) {
+        StringBuilder message = new StringBuilder("*:warning: 대기오염 경보 :warning:*\n")
+                .append("*측정소 위치:* `").append(stationName).append("`\n\n");
+
+        if (pm10 > notificationStation.getPm10Threshold()) {
+            message.append("> *미세먼지 (PM10)*: ")
+                    .append("*").append(pm10).append("㎍/㎥* ")
+                    .append("(임계치: ").append(notificationStation.getPm10Threshold()).append("㎍/㎥)\n");
+        }
+
+        if (pm25 > notificationStation.getPm25Threshold()) {
+            message.append("> *초미세먼지 (PM2.5)*: ")
+                    .append("*").append(pm25).append("㎍/㎥* ")
+                    .append("(임계치: ").append(notificationStation.getPm25Threshold()).append("㎍/㎥)\n");
+        }
+
+        return message.toString();
+    }
+}

--- a/src/main/java/com/example/realq/domain/notification/region/repository/NotificationRegionRepository.java
+++ b/src/main/java/com/example/realq/domain/notification/region/repository/NotificationRegionRepository.java
@@ -11,4 +11,6 @@ public interface NotificationRegionRepository extends JpaRepository<Notification
     Optional<NotificationRegion> findByUserEmailAndRegionId(String email, Long regionId);
 
     List<NotificationRegion> findByUserEmail(String email);
+
+    List<NotificationRegion> findAllByEnabledTrue();
 }

--- a/src/main/java/com/example/realq/domain/notification/station/repository/NotificationStationRepository.java
+++ b/src/main/java/com/example/realq/domain/notification/station/repository/NotificationStationRepository.java
@@ -12,4 +12,6 @@ public interface NotificationStationRepository extends JpaRepository<Notificatio
 
     List<NotificationStation> findByUserEmail(String email);
 
+    List<NotificationStation> findAllByEnabledTrue();
+
 }

--- a/src/main/java/com/example/realq/domain/realtime/region/client/RealtimeRegionApiClient.java
+++ b/src/main/java/com/example/realq/domain/realtime/region/client/RealtimeRegionApiClient.java
@@ -26,7 +26,7 @@ public class RealtimeRegionApiClient {
             String encodedRegion = URLEncoder.encode(region, StandardCharsets.UTF_8);
             String url = String.format(
                     "http://apis.data.go.kr/B552584/ArpltnInforInqireSvc/getCtprvnRltmMesureDnsty" +
-                            "?sidoName=%s&returnType=json&serviceKey=%s&ver=1.0",
+                            "?sidoName=%s&returnType=json&numOfRows=100&serviceKey=%s&ver=1.0",
                     encodedRegion, serviceKey
             );
             URI uri = new URI(url);


### PR DESCRIPTION
## 📝 요약

1. 사용자가 측정소별로 등록한 알림과 외부 API 호출 값을 비교하여 슬랙으로 알림 전송하는 로직 구현 
2. API 호출 시 한 페이지 결과를 명시하지 않아 측정소 639개 중 166개 데이터만 수신되는 문제 해결 
- 'numOfRows=100' 입력으로 문제 해결 
3. 팀 노션 문서에 트러블슈팅 작성
4. findAll() 메서드 대신 findAllByEnabledTrue() 메서드 생성 및 호출 

## 🛠️ PR 유형

- [ ] 배포용 PR : dev 테스트를 완료하였나요?
- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 논의사항 or 질문

## ✅ PR Checklist

PR이 다음 요구 사항을 충족했는지 확인하기!

- [x] 커밋 메시지 컨벤션 준수
- [x] 변경 사항 테스트 여부 체크(버그 수정/기능 테스트)

## 💥 리뷰어 지목!!!!!

<!--- 리뷰어를 2명 이상 지목해주세요. -->
- [x] 재성
- [ ] 지현